### PR TITLE
Remove installment of @types/react-helmet-async in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ yarn add react@^16.6.0 react-dom@^16.6.0
 This package includes its own types, as does Gatsby. To get types for the other packages, you'll need to install them separately:
 
 ```bash
-yarn add -D @types/react-helmet-async @types/react @types/react-dom
+yarn add -D @types/react @types/react-dom
 ```
 
 ## How to use


### PR DESCRIPTION
As reference, react-helmet-async provides its own type definitions, so we do not need this @types  installed.
https://www.npmjs.com/package/@types/react-helmet-async